### PR TITLE
Remove deprecated Imputer

### DIFF
--- a/Code/Day 1_Data PreProcessing.md
+++ b/Code/Day 1_Data PreProcessing.md
@@ -19,8 +19,8 @@ Y = dataset.iloc[ : , 3].values
 ```
 ## Step 3: Handling the missing data
 ```python
-from sklearn.preprocessing import Imputer
-imputer = Imputer(missing_values = "NaN", strategy = "mean", axis = 0)
+from sklearn.impute import SimpleImputer
+imputer = SimpleImputer(missing_values = np.nan, strategy = "mean")
 imputer = imputer.fit(X[ : , 1:3])
 X[ : , 1:3] = imputer.transform(X[ : , 1:3])
 ```


### PR DESCRIPTION
I got the warning of deprecated class
`/usr/local/lib/python3.6/dist-packages/sklearn/utils/deprecation.py:66: DeprecationWarning: Class Imputer is deprecated; Imputer was deprecated in version 0.20 and will be removed in 0.22. Import impute.SimpleImputer from sklearn instead.
  warnings.warn(msg, category=DeprecationWarning)`

So using `SimpleImputer` instead

## Pull Request Prelude
Thank you for your contribution :)

Please complete the below steps before filing your PR:

 I have read and understood CONTRIBUTING document.
 I have read and understood  CODE_OF_CONDUCT document.
 I have included tests for the changes in my PR. If not, I have included a rationale for why I haven't.
 I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.
## Why this change is necessary and useful
[Please explain in detail why the changes in this PR are needed.]
