### PR TITLE
Update Day 1_Data PreProcessing.md

### DIFF
--- a/Code/Day 1_Data PreProcessing.md
+++ b/Code/Day 1_Data PreProcessing.md
@@ -19,8 +19,8 @@ Y = dataset.iloc[ : , 3].values
 ```
 ## Step 3: Handling the missing data
 ```python
-from sklearn.preprocessing import Imputer
-imputer = Imputer(missing_values = "NaN", strategy = "mean", axis = 0)
+from sklearn.impute import SimpleImputer
+imputer = SimpleImputer(missing_values = np.nan, strategy = "mean")
 imputer = imputer.fit(X[ : , 1:3])
 X[ : , 1:3] = imputer.transform(X[ : , 1:3])
 ```


### PR DESCRIPTION
from sklearn.preprocessing import Imputer was deprecated with scikit-learn v0.20.4 and removed as of v0.22.2
